### PR TITLE
Fix delete button layout shift

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -155,7 +155,7 @@ export default function Home() {
                   feed.title || feedUrl
                 )}{" "}
                 <button onClick={() => onRemoveClick(feedUrl, feed.title)}>
-                  X
+                  ❌
                 </button>
               </h3>
               <NewItemsList

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -72,11 +72,16 @@ h3 {
 }
 
 h3 button {
-  display: none;
+  will-change: opacity;
+
+  opacity: 0;
+  border-radius: 50%;
+
+  transition: opacity 300ms ease-in-out;
 }
 
 h3:hover button {
-  display: inline-block;
+  opacity: 1;
 }
 
 button {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -73,10 +73,7 @@ h3 {
 
 h3 button {
   will-change: opacity;
-
   opacity: 0;
-  border-radius: 50%;
-
   transition: opacity 300ms ease-in-out;
 }
 


### PR DESCRIPTION
Currently the button simply pops in and out of existence and it causes a layout shift, which some users might find annoying (me included).

I've made it so that it fades in and out while preserving the space on the page and negating any layout shifting.