### PR TITLE
Fix Next export

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,3 @@
+export default function ({ src }) {
+  return src;
+}

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  images: {
+    loader: "custom",
+    loaderFile: "./loader.js",
+  },
+};


### PR DESCRIPTION
Image Optimization using Next.js' default loader is not compatible with `next export`.
If we're using SSG we need to create a custom loader.