### PR TITLE
Add loaders for each feed section

### DIFF
--- a/models/SiteFeed.ts
+++ b/models/SiteFeed.ts
@@ -3,6 +3,7 @@ import RSSParser from "rss-parser";
 export interface Feed extends RSSParser.Output<RSSParser.Item>, SiteFeed {
   favicon?: string;
   visited: Record<string, boolean>;
+  loaded?: boolean;
 }
 
 export interface SiteFeed {

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,7 +11,6 @@ import {
   HeadMeta,
   NewFeedForm,
   NewItemsList,
-  ProgressLoader,
   VisitedItemsList,
 } from "../components";
 import { Feed } from "../models";
@@ -83,6 +82,7 @@ export default function Home() {
           ...feedArchive[feedUrl],
           visited: storage[feedUrl].visited,
           priority: storage[feedUrl].priority,
+          loaded: true
         };
         continue;
       }
@@ -95,13 +95,14 @@ export default function Home() {
           favicon: feedFavicon,
           visited: storage[feedUrl].visited || {},
           priority: storage[feedUrl].priority,
+          loaded: false
         };
 
         if (feedToUpdate.priority && feedToUpdate.priority > highestPriority) {
           highestPriority = feedToUpdate.priority;
         }
 
-        storage[feedUrl] = feedToUpdate;
+        storage[feedUrl] = {...feedToUpdate, loaded: true};
       } catch {
         console.error(`Could not update feed for ${feedUrl}`);
       }
@@ -179,8 +180,6 @@ export default function Home() {
 
     return keys;
   }, [feedArchive]);
-
-  const isContentLoading = loadedFeeds.loaded !== loadedFeeds.total;
 
   const onFavoriteClick = useCallback(
     async (feed: Feed) => {
@@ -291,7 +290,7 @@ export default function Home() {
                   ) : (
                     feed.title || feedUrl
                   )}{" "}
-                  {isContentLoading && (
+                  {!feed.loaded && (
                     <>
                     <span className={Styles.bounceLoader}></span>
                     <span className={Styles.rotateTimeLoader}>⏳</span>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -180,6 +180,8 @@ export default function Home() {
     return keys;
   }, [feedArchive]);
 
+  const isContentLoading = loadedFeeds.loaded !== loadedFeeds.total;
+
   const onFavoriteClick = useCallback(
     async (feed: Feed) => {
       const resortedArchive = sortedArchive
@@ -260,7 +262,6 @@ export default function Home() {
             Favorites
           </button>
         </div>
-        <ProgressLoader loadedFeeds={loadedFeeds} />
         {activeTab === "feeds" &&
           sortedArchive.map((feedUrl) => {
             const feed = feedArchive[feedUrl];
@@ -290,9 +291,22 @@ export default function Home() {
                   ) : (
                     feed.title || feedUrl
                   )}{" "}
+                  {isContentLoading && (
+                    <>
+                    <span className={Styles.loader2}>⏳</span>
+                    <span className={Styles.loader3}>🔄</span>
+                    <span className={Styles.loader4}>🧠</span>
+                    </>
+                  )}
                   <button onClick={() => onRemoveClick(feedUrl, feed.title)}>
                     ❌
                   </button>
+                  {isContentLoading && (
+                    <>
+                    <span className={Styles.loader1}></span>
+                    <span className={Styles.loader5}></span>
+                    </>
+                  )}
                 </h3>
                 <NewItemsList
                   feed={feed}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -293,20 +293,17 @@ export default function Home() {
                   )}{" "}
                   {isContentLoading && (
                     <>
-                    <span className={Styles.loader2}>⏳</span>
-                    <span className={Styles.loader3}>🔄</span>
-                    <span className={Styles.loader4}>🧠</span>
+                    <span className={Styles.bounceLoader}></span>
+                    <span className={Styles.rotateTimeLoader}>⏳</span>
+                    <span className={Styles.flipTimeLoader}>⏳</span>
+                    <span className={Styles.rotateArrowsLoader}>🔄</span>
+                    <span className={Styles.heartbeatBrainLoader}>🧠</span>
+                    <span className={Styles.typewriteLoader}></span>
                     </>
                   )}
                   <button onClick={() => onRemoveClick(feedUrl, feed.title)}>
                     ❌
                   </button>
-                  {isContentLoading && (
-                    <>
-                    <span className={Styles.loader1}></span>
-                    <span className={Styles.loader5}></span>
-                    </>
-                  )}
                 </h3>
                 <NewItemsList
                   feed={feed}

--- a/styles/index.module.css
+++ b/styles/index.module.css
@@ -29,28 +29,30 @@
   margin: 1em 0;
 }
 
-
-.loader1::after {
+.typewriteLoader::after {
   content: "...";
   animation: typewriter 1.5s infinite;
 }
 
-.loader2 {
+.flipTimeLoader {
   animation: flip 1.5s infinite ease-in-out;
 }
 
-.loader3 {
+.rotateTimeLoader,
+.rotateArrowsLoader {
   animation: rotate 1.5s infinite ease-in-out;
 }
 
-.loader4 {
+.heartbeatBrainLoader {
   animation: heartbeat 1.5s infinite ease-in-out;
 }
 
-.loader5 {
+.bounceLoader {
   width: 8px;
   height: 8px;
   border-radius: 50%;
+  display: inline-block;
+  margin-left: 15px;
   background: #ee802f;
   animation: bounce 1.2s infinite cubic-bezier(0.68, -0.55, 0.265, 1.55);
 }
@@ -61,7 +63,7 @@
     transform: translateX(0);
   }
   50% {
-    transform: translateX(-20px) scale(0.8);
+    transform: translateX(-15px) scale(0.8);
   }
 }
 
@@ -86,11 +88,11 @@
   }
 
   50% {
-    transform: rotate(180deg);
+    transform: rotate(-180deg);
   }
 
   100% {
-    transform: rotate(360deg);
+    transform: rotate(-360deg);
   }
 }
 

--- a/styles/index.module.css
+++ b/styles/index.module.css
@@ -28,3 +28,97 @@
   gap: 0.75em;
   margin: 1em 0;
 }
+
+
+.loader1::after {
+  content: "...";
+  animation: typewriter 1.5s infinite;
+}
+
+.loader2 {
+  animation: flip 1.5s infinite ease-in-out;
+}
+
+.loader3 {
+  animation: rotate 1.5s infinite ease-in-out;
+}
+
+.loader4 {
+  animation: heartbeat 1.5s infinite ease-in-out;
+}
+
+.loader5 {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #ee802f;
+  animation: bounce 1.2s infinite cubic-bezier(0.68, -0.55, 0.265, 1.55);
+}
+
+@keyframes bounce {
+  0%,
+  100% {
+    transform: translateX(0);
+  }
+  50% {
+    transform: translateX(-20px) scale(0.8);
+  }
+}
+
+@keyframes typewriter {
+  0% {
+    content: "";
+  }
+  25% {
+    content: ".";
+  }
+  50% {
+    content: "..";
+  }
+  75% {
+    content: "...";
+  }
+}
+
+@keyframes rotate {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  50% {
+    transform: rotate(180deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes heartbeat {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  14% {
+    transform: scale(1.3);
+  }
+  28% {
+    transform: scale(1);
+  }
+  42% {
+    transform: scale(1.3);
+  }
+  70% {
+    transform: scale(1);
+  }
+}
+
+@keyframes flip {
+  0%,
+  50% {
+    transform: rotateY(0deg);
+  }
+  100% {
+    transform: rotateY(180deg);
+  }
+}


### PR DESCRIPTION
Added 6 styles to show the loading state for the feeds, and removed the one at the top of the page.

https://github.com/user-attachments/assets/960f19b2-f664-4531-932b-083d067e22cd

@strdr4605 Could you please let me know which style you'd prefer and if this solution is correct?
Currently the loader is visible in all the sections regardless if the list of feed items is loaded or not. The loaders appear as long as all the feeds are appearing on the page. I was thinking if we need to hide the loader from a section once we have that section's list of items loaded, but I assume we would need to track a different state for that. Am I right?