### PR TITLE
refactor: replace interface with type

### DIFF
--- a/src/components/ExternalLink/ExternalLink.tsx
+++ b/src/components/ExternalLink/ExternalLink.tsx
@@ -1,7 +1,7 @@
 import { MouseEvent } from "react";
 import Styles from "./ExternalLink.module.css";
 
-export interface Props {
+export type Props = {
   link: string;
   title?: string;
   onClick?: (e: MouseEvent<HTMLAnchorElement>) => void;

--- a/src/components/FavoritePin/FavoritePin.tsx
+++ b/src/components/FavoritePin/FavoritePin.tsx
@@ -2,7 +2,7 @@ import { useMemo } from "react";
 import { Feed } from "../../models";
 import Styles from "./FavoritePin.module.css";
 
-interface FavoritePinProps {
+type FavoritePinProps = {
   feed: Feed;
   onClick: (feed: Feed) => void;
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,7 @@ import { setDarkMode, setLightMode } from "../../utils";
 import { ExternalLink } from "../ExternalLink/ExternalLink";
 import Styles from "./Header.module.css";
 
-interface HeaderProps {
+type HeaderProps = {
   onNavigate?: (page: string) => void
 }
 

--- a/src/models/Favorite.ts
+++ b/src/models/Favorite.ts
@@ -1,6 +1,6 @@
 import RSSParser from "rss-parser";
 
-export interface Favorite extends RSSParser.Item {
+export type Favorite = RSSParser.Item & {
   url: string;
   sourceFeedUrl?: string;
   sourceFeedTitle?: string;

--- a/src/models/SiteFeed.ts
+++ b/src/models/SiteFeed.ts
@@ -1,12 +1,12 @@
 import RSSParser from "rss-parser";
 
-export interface Feed extends RSSParser.Output<RSSParser.Item>, SiteFeed {
+export type Feed = RSSParser.Output<RSSParser.Item> & SiteFeed & {
   favicon?: string;
   visited: Record<string, boolean>;
   loaded?: boolean;
 }
 
-export interface SiteFeed {
+export type SiteFeed = {
   url: string;
   priority?: number;
   visited?: Record<string, boolean>;

--- a/src/models/TransferFeed.ts
+++ b/src/models/TransferFeed.ts
@@ -1,13 +1,13 @@
 import { Feed } from "../models";
 import { Favorite } from "./Favorite";
 
-export interface TransferData {
+export type TransferData = {
   db: number;
   feed?: TransferFeed[];
   favorites?: Favorite[];
 }
 
-export interface TransferFeed extends Omit<Feed, "visited"> {
+export type TransferFeed = Omit<Feed, "visited"> & {
   domain?: string; // deprecated, kept for backwards compatibility
   visited?: string[];
 }

--- a/src/pages/Feeds.tsx
+++ b/src/pages/Feeds.tsx
@@ -5,7 +5,7 @@ import { insertSiteFeed } from "../services/indexeddbService";
 import Style from "../styles/feeds.module.css";
 import { getFavicon } from "../utils";
 
-interface JSONFeed {
+type JSONFeed = {
   siteUrl: string;
   feedUrl: string;
   description: string;

--- a/src/services/migrations/V1_init_database.ts
+++ b/src/services/migrations/V1_init_database.ts
@@ -10,13 +10,13 @@ export async function V1_init_database(db: IDBPDatabase) {
   localStorageData.forEach((data) => insertSiteFeed(data));
 }
 
-interface LocalStorage {
+type LocalStorage = {
   items: LocalStorageFeed[];
   title: string;
   visited: any;
 }
 
-interface LocalStorageFeed {
+type LocalStorageFeed = {
   title: string;
   link: string;
   author: string;


### PR DESCRIPTION
Closes #76

Replace all `interface` declarations with `type` across the codebase.