### PR TITLE
feat: OPML export/import

### DIFF
--- a/src/components/ExportImportForm/ExportImportForm.module.css
+++ b/src/components/ExportImportForm/ExportImportForm.module.css
@@ -3,6 +3,16 @@
     cursor: pointer;
   }
 
+  .exportButtons {
+    display: flex;
+    gap: 0.75rem;
+    margin-bottom: 1em;
+
+    button {
+      margin: 0;
+    }
+  }
+
   button {
     margin: 0;
     margin-bottom: 1em;

--- a/src/components/ExportImportForm/ExportImportForm.tsx
+++ b/src/components/ExportImportForm/ExportImportForm.tsx
@@ -52,6 +52,7 @@ export function ExportImportForm() {
       </div>
       <hr />
       <p>Import from file</p>
+      <p>Supports JSON (from another cofeed instance) or OPML (from any RSS reader).</p>
       <input type="file" name="my_files[]" accept=".json,.opml" onChange={onFileLoad} />
     </details>
   );

--- a/src/components/ExportImportForm/ExportImportForm.tsx
+++ b/src/components/ExportImportForm/ExportImportForm.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent } from "react";
-import { exportData, importDataFromFile } from "../../services/exportService";
+import { exportData, exportOPML, importDataFromFile, importOPMLFromFile } from "../../services/exportService";
 import Styles from "./ExportImportForm.module.css";
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
@@ -19,10 +19,19 @@ async function onExportClick() {
   exportData();
 }
 
+async function onExportOPMLClick() {
+  exportOPML();
+}
+
 async function onFileLoad(e: ChangeEvent<HTMLInputElement>) {
   const dataFile = e.target.files?.[0];
   const text = await dataFile?.text();
-  text && importDataFromFile(text);
+  if (!text) return;
+  if (dataFile?.name.endsWith(".opml")) {
+    importOPMLFromFile(text);
+  } else {
+    importDataFromFile(text);
+  }
 }
 
 export function ExportImportForm() {
@@ -37,10 +46,13 @@ export function ExportImportForm() {
       </p>
       <p>Last exported: {lastExported}</p>
       <p>Next reminder: {nextReminder}</p>
-      <button onClick={onExportClick}>Export data</button>
+      <div className={Styles.exportButtons}>
+        <button onClick={onExportClick}>Export data</button>
+        <button onClick={onExportOPMLClick}>Export OPML</button>
+      </div>
       <hr />
       <p>Import from file</p>
-      <input type="file" name="my_files[]" onChange={onFileLoad} />
+      <input type="file" name="my_files[]" accept=".json,.opml" onChange={onFileLoad} />
     </details>
   );
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -60,7 +60,7 @@ export function Header({ onNavigate }: HeaderProps) {
             </a>
             😊.
           </li>
-          <li>Supports RSS and Atom feeds</li>
+          <li>Supports RSS and Atom feeds (OPML import/export also supported)</li>
           <li>
             Try <u>http</u> and <u>https</u>
           </li>

--- a/src/services/exportService.ts
+++ b/src/services/exportService.ts
@@ -31,7 +31,7 @@ export async function exportData() {
   };
 
   download(
-    new Date().toLocaleDateString("uk-en") + "-cofeed.json",
+    new Date().toISOString().slice(0, 10) + "-cofeed.json",
     JSON.stringify(transferData, undefined, 2)
   );
   localStorage.setItem("cofeed_last_export_date", Date.now().toString());
@@ -55,7 +55,7 @@ ${outlines}
 </opml>`;
 
   download(
-    new Date().toLocaleDateString("uk-en") + "-cofeed.opml",
+    new Date().toISOString().slice(0, 10) + "-cofeed.opml",
     opml
   );
   localStorage.setItem("cofeed_last_export_date", Date.now().toString());


### PR DESCRIPTION
## Summary
- Add `exportOPML` and `importOPMLFromFile` to `exportService.ts` using native `DOMParser` and template literals
- Add "Export OPML" button and route `.opml` files to correct handler in `ExportImportForm`
- Add e2e tests for OPML export and import

## Test plan
- [x] All 26 e2e tests pass
- [x] Manual: add feed → Export OPML → verify `.opml` file downloads with correct XML
- [x] Manual: import `.opml` file → verify feeds appear

Closes #70