### PR TITLE
fix: visited state broken for feeds with whitespace in links

### DIFF
--- a/e2e/persistence.spec.ts
+++ b/e2e/persistence.spec.ts
@@ -1,6 +1,28 @@
 import { test, expect } from "./fixtures";
 import { setupMockFeed, MOCK_FEED_URL } from "./helpers/mockFeeds";
 
+const FEED_WITH_WHITESPACE_LINKS = `<?xml version="1.0"?>
+<rss version="2.0">
+  <channel>
+    <title>Test Feed</title>
+    <link>https://example.com</link>
+    <item>
+      <title>Test Article 1</title>
+      <link>
+https://example.com/article1
+</link>
+      <pubDate>Mon, 20 Feb 2026 00:00:00 GMT</pubDate>
+    </item>
+    <item>
+      <title>Test Article 2</title>
+      <link>
+https://example.com/article2
+</link>
+      <pubDate>Sun, 19 Feb 2026 00:00:00 GMT</pubDate>
+    </item>
+  </channel>
+</rss>`;
+
 test.describe("Data Persistence", () => {
   test("should persist feeds across page reloads", async ({ page }) => {
     await setupMockFeed(page);
@@ -32,6 +54,19 @@ test.describe("Data Persistence", () => {
     await page.locator('summary:has-text("Visited from")').click();
 
     await expect(page.locator('[data-testid="visited-item"]')).toHaveCount(1);
+    await expect(page.locator('[data-testid="new-item"]')).toHaveCount(1);
+  });
+
+  test("should mark item as visited when link has surrounding whitespace", async ({ page }) => {
+    await page.route(MOCK_FEED_URL, (route) =>
+      route.fulfill({ status: 200, contentType: "application/rss+xml", body: FEED_WITH_WHITESPACE_LINKS })
+    );
+    await page.fill('input[placeholder*="https://"]', MOCK_FEED_URL);
+    await page.click('button:has-text("Add feeds")');
+    await expect(page.locator('[data-testid="new-item"]')).toHaveCount(2);
+
+    await page.locator('[data-testid="new-item"] a').first().click();
+
     await expect(page.locator('[data-testid="new-item"]')).toHaveCount(1);
   });
 });

--- a/src/components/NewItemsList/NewItemsList.tsx
+++ b/src/components/NewItemsList/NewItemsList.tsx
@@ -19,7 +19,7 @@ const onLinkClick = async (feedUrl?: string, itemLink?: string) => {
 
   const siteFeed = await getSiteFeed(feedUrl);
   if (siteFeed.visited) {
-    siteFeed.visited[itemLink] = true;
+    siteFeed.visited[itemLink.trim()] = true;
   }
 
   await updateSiteFeed(siteFeed);
@@ -33,7 +33,7 @@ const markAllAsVisited = async (feedUrl: string, itemLinks: string[]) => {
   const siteFeed = await getSiteFeed(feedUrl);
   if (siteFeed.visited) {
     for (const itemLink of itemLinks) {
-      siteFeed.visited[itemLink] = true;
+      siteFeed.visited[itemLink.trim()] = true;
     }
   }
 
@@ -52,7 +52,7 @@ export function NewItemsList(props: Props) {
       if (!old) return old;
       const visited = { ...old.visited };
       for (const link of links) {
-        visited[link] = true;
+        visited[link.trim()] = true;
       }
       return { ...old, visited };
     });


### PR DESCRIPTION
## Bug

Some RSS feeds (e.g. `https://antirez.com/rss`) include surrounding whitespace/newlines in their `<link>` elements:

```xml
<link>
http://antirez.com/news/158
</link>
```

`FeedSection` correctly filters using `item.link.trim()`, so visited items are excluded from the new items list. However, when storing the visited key, `item.link` was used **without trimming** — causing a key mismatch. The stored key was `\nhttp://antirez.com/news/158\n` but the lookup key was `http://antirez.com/news/158`, so items were never considered visited.

## Fix

`.trim()` the link when storing the visited key in `onLinkClick`, `markAllAsVisited`, and `markVisitedInCache` — consistent with the existing `.trim()` in the filter.

## Test

Added an e2e test in `persistence.spec.ts` that reproduces the bug using a mock feed with whitespace-padded `<link>` tags.